### PR TITLE
Fix server auto-run on import

### DIFF
--- a/server.py
+++ b/server.py
@@ -41,5 +41,6 @@ def home():
         print('unknow req')
 
 
-app.run()
+if __name__ == "__main__":
+    app.run()
 


### PR DESCRIPTION
## Summary
- ensure Flask server only runs when executed directly

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_683fd5a14c908329b459c9d94bfa89f0