### PR TITLE
Add Flask route test and fix server main

### DIFF
--- a/server.py
+++ b/server.py
@@ -41,5 +41,6 @@ def home():
         print('unknow req')
 
 
-app.run()
+if __name__ == "__main__":
+    app.run()
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,13 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import server
+
+def test_root_get():
+    app = server.app
+    with app.test_client() as client:
+        response = client.get('/')
+        assert response.status_code == 200
+        assert response.data.decode('utf-8') == 'testing :)'


### PR DESCRIPTION
## Summary
- ensure `server` only runs when executed directly
- add pytest for `/` route in `server`

## Testing
- `pip install -q -r requirements.txt` *(fails: 403 Forbidden)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_683fd5a42df88329ab10401b26851338