### PR TITLE
Fix model loading and add training script

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,10 @@ A. Absolutely. Our Truity @ Work platform is designed to make it easy to give th
 
 #### Q. What is the difference between Big Five, Five Factor, and the OCEAN model of personality?<br>
 A. Big Five, Five Factor, and OCEAN are all ways of describing the same theory of personality. Multiple psychological studies have arrived at the conclusion that the differences between people's personalities can be organized into five broad categories, called the Big Five or Five Factors. These are sometimes referred to as the five broad dimensions of personality.
+
+## Training the Model
+To generate the `trained_Model.pkl` used by the backend, download `data-final.csv` from Kaggle and place it under `data/`. Then run:
+```bash
+python train_model.py
+```
+This will create the pickle file in the project root that the Flask app loads.

--- a/ml.py
+++ b/ml.py
@@ -1,4 +1,5 @@
 import pickle
+import os
 import pandas as pd
 import numpy as np
 
@@ -19,10 +20,13 @@ class Predictor:
     model = None
 
     def prepPredictor(self):
-        infile = open('/home/kiani/awais/trained_Model.pkl','rb')
-        self.model = pickle.load(infile)
+        """Load the trained model from the repository."""
+        model_path = os.path.join(os.path.dirname(__file__), 'trained_Model.pkl')
+        with open(model_path, 'rb') as infile:
+            self.model = pickle.load(infile)
 
     def predict(self, data):
+        """Predict the cluster for the given data array."""
         new_result = self.model.predict(data)
         return new_result[0]
 

--- a/train_model.py
+++ b/train_model.py
@@ -1,0 +1,26 @@
+import pandas as pd
+from sklearn.cluster import KMeans
+import pickle
+
+
+def main():
+    # Path to the Kaggle dataset downloaded separately
+    data_path = "data/data-final.csv"
+    df_raw = pd.read_csv(data_path, sep='\t')
+    data = df_raw.copy()
+    # remove additional questionnaire columns
+    data.drop(data.columns[50:107], axis=1, inplace=True)
+    data.drop(data.columns[51:], axis=1, inplace=True)
+
+    # drop country column for modelling
+    df_model = data.drop('country', axis=1)
+
+    kmeans = KMeans(n_clusters=5, random_state=42)
+    kmeans.fit(df_model)
+
+    with open('trained_Model.pkl', 'wb') as f:
+        pickle.dump(kmeans, f)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- update `ml.py` to load the model from the project directory
- add `train_model.py` to recreate the KMeans model from Kaggle data
- document training instructions in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683fe339d10c8329920fbed3a92a7bfa