### PR TITLE
Fix submit handler to send data

### DIFF
--- a/client/src/Home.js
+++ b/client/src/Home.js
@@ -14,13 +14,12 @@ export default function Home() {
   const [question, setQuestion] = useState(questions);
   const [enableSubmit, setEnableSubmit] = useState(false);
   const [final, setFinal] = useState("");
-  const [selections, setSelections] = useState([
-    Object.keys(questions).map((x) => []),
-  ]);
+  const [selections, setSelections] = useState(
+    Array(questions.length).fill(null)
+  );
 
   const submitHandler = () => {
-    const result = Object.values(selections);
-    result.shift();
+    const result = [...selections];
     console.log(result);
     console.log(enableSubmit);
 
@@ -67,28 +66,23 @@ export default function Home() {
 
         .then((response) => {
           console.log(response);
-          // console.log(response.data?.output);
-          setFinal(response.data?.output);
-          console.log(final.length);
+          const output = response.data?.output;
+          setFinal(output);
           setEnableSubmit(true);
-          if (final.length >= 1) {
-            history.push("/prediction", {
-              averages: allAverages,
-              trait: final,
-            });
-          }
+          history.push("/prediction", {
+            averages: allAverages,
+            trait: output,
+          });
         })
         .catch((error) => console.log("The axios Error", error));
     }
 
-    if (result.length === 50) {
+    if (!result.includes(null)) {
       personalPredictor();
-      // history.push("/prediction", { averages: allAverages });
-      // setEnableSubmit(true);
     }
   };
   const handleChange = (selection, index) => {
-    let tempState = { ...selections };
+    const tempState = [...selections];
     tempState[index] = selection;
     setSelections(tempState);
   };


### PR DESCRIPTION
## Summary
- initialize question selections as a 50-element array
- remove shift() usage and rely on array contents directly
- push to prediction page using API response
- ensure change handler works with array state

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68589e3817f08329872cd25d2dd4e376