### PR TITLE
Add POST root endpoint test

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -11,3 +11,12 @@ def test_root_get():
         response = client.get('/')
         assert response.status_code == 200
         assert response.data.decode('utf-8') == 'testing :)'
+
+def test_root_post():
+    app = server.app
+    server.predictor.prepPredictor()
+    with app.test_client() as client:
+        response = client.post('/', json={"text": [1] * 50})
+        assert response.status_code == 200
+        data = response.get_json()
+        assert "output" in data


### PR DESCRIPTION
## Summary
- extend server tests to cover POST request

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858a43616908329a30ccc851ad4033e