### PR TITLE
Fix question indexing bug

### DIFF
--- a/client/src/Home.js
+++ b/client/src/Home.js
@@ -116,7 +116,7 @@ export default function Home() {
                   name={`question_${question.indexOf(item)}`}
                 >
                   <h3 className="question-text">
-                    <span style={{ color: "black" }}>{++index + ") "}</span>
+                    <span style={{ color: "black" }}>{index + 1 + ") "}</span>
                     {item.question}
                   </h3>
                   <form className="choices">


### PR DESCRIPTION
## Summary
- ensure index is not mutated when rendering question numbers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861cda056b4832985554b01f424fd5e